### PR TITLE
Add Unify_Map function to unify the input MRC file before resampling

### DIFF
--- a/data_processing/Unify_Map.py
+++ b/data_processing/Unify_Map.py
@@ -1,0 +1,53 @@
+
+import mrcfile
+import numpy as np
+from pathlib import Path
+
+def Unify_Map(input_map_path, new_map_path):
+    # Read MRC file
+    mrc = mrcfile.open(input_map_path, mode='r')
+
+    data = mrc.data.copy()
+    voxel_size = np.asarray(mrc.voxel_size.tolist(), dtype=np.float32)
+    origin = np.array(mrc.header.origin.tolist(), dtype=np.float32)
+    nstart = np.asarray([mrc.header.nxstart, mrc.header.nystart, mrc.header.nzstart], dtype=np.float32)
+    cellb = np.array(mrc.header.cellb.tolist(), dtype=np.float32)
+    mapcrs = np.asarray([mrc.header.mapc, mrc.header.mapr, mrc.header.maps], dtype=int)
+    mrc.print_header()
+    mrc.close()
+
+    # Check orthogonality
+    try:
+        assert (cellb[0] == cellb[1] == cellb[2] == 90.0)
+    except AssertionError:
+        print("Error! We can only process orthogonal map.")
+        mrc.close()
+        exit()
+
+    # Reorder
+    sort = np.asarray([0, 1, 2], dtype=np.int64)
+    for i in range(3):
+        sort[mapcrs[i]-1] = i
+    nstart = np.asarray([nstart[i] for i in sort])
+    voxel_size = np.asarray([voxel_size[i] for i in sort])
+    data = np.transpose(data, axes=2-sort[::-1])
+
+    # Move offsets from nstart to origin
+    origin = origin + nstart * voxel_size
+
+    # Save the unified map
+    mrc_new = mrcfile.new(new_map_path, data=data, overwrite=True)
+    (mrc_new.header.origin.x, mrc_new.header.origin.y, mrc_new.header.origin.z) = origin
+    mrc_new.voxel_size = [voxel_size[i] for i in range(3)]
+    mrc_new.update_header_stats()
+    mrc_new.print_header()
+    mrc_new.close()
+
+
+
+
+
+if __name__ == "__main__":
+    input_map_path = Path('../example/21051.mrc')
+    new_map_path = Path('../example/21051_unified.mrc')
+    Unify_Map(input_map_path, new_map_path)

--- a/data_processing/Unify_Map.py
+++ b/data_processing/Unify_Map.py
@@ -1,7 +1,8 @@
+from pathlib import Path
 
 import mrcfile
 import numpy as np
-from pathlib import Path
+
 
 def Unify_Map(input_map_path, new_map_path):
     # Read MRC file
@@ -27,10 +28,10 @@ def Unify_Map(input_map_path, new_map_path):
     # Reorder
     sort = np.asarray([0, 1, 2], dtype=np.int64)
     for i in range(3):
-        sort[mapcrs[i]-1] = i
+        sort[mapcrs[i] - 1] = i
     nstart = np.asarray([nstart[i] for i in sort])
     voxel_size = np.asarray([voxel_size[i] for i in sort])
-    data = np.transpose(data, axes=2-sort[::-1])
+    data = np.transpose(data, axes=2 - sort[::-1])
 
     # Move offsets from nstart to origin
     origin = origin + nstart * voxel_size
@@ -42,9 +43,6 @@ def Unify_Map(input_map_path, new_map_path):
     mrc_new.update_header_stats()
     mrc_new.print_header()
     mrc_new.close()
-
-
-
 
 
 if __name__ == "__main__":

--- a/main.py
+++ b/main.py
@@ -36,6 +36,8 @@ if __name__ == "__main__":
             save_path=params['output']
             map_name="input"
             mkdir(save_path)
+        from data_processing.Unify_Map import Unify_Map
+        cur_map_path = Unify_Map(cur_map_path,os.path.join(save_path,map_name+"_unified.mrc"))
         from data_processing.Resize_Map import Resize_Map
         cur_map_path = Resize_Map(cur_map_path,os.path.join(save_path,map_name+".mrc"))
         from predict.predict_1st_stage import Predict_1st_Stage


### PR DESCRIPTION
Add Unify_Map function to unify the input MRC file before resampling:

- Unify the (mapc, mapr, maps) = (1,2,3)
- Move the offsets from (nxstart, nystart, nzstart) to origin and set (nxstart, nystart, nzstart) = (0, 0, 0)